### PR TITLE
Fixes for _node_resource_index() issues

### DIFF
--- a/resources/node_resource.inc
+++ b/resources/node_resource.inc
@@ -279,6 +279,11 @@ function _node_resource_index($page = 0, $fields = '*', $parameters = array()) {
   $parameters = (array) $parameters;
   $schema = drupal_get_schema('node');
   $where = array();
+ 
+  if (empty($fields)) {
+    $fields = '*';
+  }
+ 
   $fields = db_escape_string($fields);
 
 
@@ -298,7 +303,7 @@ function _node_resource_index($page = 0, $fields = '*', $parameters = array()) {
   $where = !empty($where) ? ' WHERE '. db_escape_string(implode(' AND ', $where)) : '';
 
   // Run through db_rewrite_sql to make sure proper access checks are applied.
-  $sql = "SELECT $fields FROM {node} $where ORDER BY sticky DESC, created DESC";
+  $sql = "SELECT $fields FROM {node} n $where ORDER BY sticky DESC, created DESC";
   $sql = db_rewrite_sql($sql);
   $result = db_query_range($sql, $parameters, $page * 20, 20);
 


### PR DESCRIPTION
Hi!

I had problems getting the node index working. Found two issues in _node_resource_index():
1. The $fields variable is empty instead of '*'. Added a check for this as suggested here: http://drupal.org/node/985312.
2. The WHERE causes uses an `n` alias for the `node` table column, but it's not defined so it fails.

Here's the error:

```
Unknown column 'n.language' in 'where clause'; query: SELECT * FROM node WHERE (n.language ='sv' OR n.language ='' OR n.language IS NULL) ORDER BY sticky DESC, created DESC LIMIT 0,20
```

Cheers,

Henrik
